### PR TITLE
- future parser uses data types, hence we have to check for string

### DIFF
--- a/manifests/check_mk/plugins/puppet.pp
+++ b/manifests/check_mk/plugins/puppet.pp
@@ -3,7 +3,7 @@ class omd::check_mk::plugins::puppet(
 ) {
   
   $pyyaml_pkg=$::osfamily ? {
-    Debian => 'python-yaml',
+    'Debian' => 'python-yaml',
     default => PyYAML,
   }
 


### PR DESCRIPTION
With the future parser, facts are data types now  

```
[01:20 PM]-[root@agent1]-[~] # puppet apply --parser=future -e 'notify {"OS: $::osfamily":} $pyyaml_pkg=Debian ? {Debian => 'python-yaml',default => PyYAML,} notify {"PACKAGE: $pyyaml_pkg":}'
Notice: Compiled catalog for agent1.puppet.local in environment production in 0.47 seconds
Notice: OS: Debian
Notice: /Stage[main]/Main/Notify[OS: Debian]/message: defined 'message' as 'OS: Debian'
Notice: PACKAGE: Pyyaml
Notice: /Stage[main]/Main/Notify[PACKAGE: Pyyaml]/message: defined 'message' as 'PACKAGE: Pyyaml'
Notice: Finished catalog run in 0.31 seconds
```

```
[01:23 PM]-[root@agent1]-[~] # puppet apply  -e 'notify {"OS: $::osfamily":} $pyyaml_pkg=Debian ? {Debian => 'python-yaml',default => PyYAML,} notify {"PACKAGE: $pyyaml_pkg":}'
Notice: Compiled catalog for agent1.puppet.local in environment production in 0.01 seconds
Notice: OS: Debian
Notice: /Stage[main]/Main/Notify[OS: Debian]/message: defined 'message' as 'OS: Debian'
Notice: PACKAGE: python-yaml
Notice: /Stage[main]/Main/Notify[PACKAGE: python-yaml]/message: defined 'message' as 'PACKAGE: python-yaml'
Notice: Finished catalog run in 0.18 seconds
```
